### PR TITLE
feature: add Hours endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ $locations = $client->space()->locations()->cache()->send();
 It is recommended to consult your Simple Cache client's documentation on how to best set up the cache to preserve entries between processes.
 
 ## Limitations
-This client currently only implements the Spaces/Seats endpoints under `/space`.
+This client currently only implements the Spaces/Seats endpoints under `/space` and and the Hours endpoint at `/hours`.
 
 ## Related Projects
 [An application that provides a public interface for space booking](https://github.com/bgsu-lits/book) using this library is also available from the BGSU University Libraries.

--- a/src/Action/HoursAction.php
+++ b/src/Action/HoursAction.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lits\LibCal\Action;
+
+use Lits\LibCal\Action;
+use Lits\LibCal\Client;
+use Lits\LibCal\Data\Hours\HoursData;
+use Lits\LibCal\Exception\ActionException;
+
+/** Action to get opening hours for a location. */
+class HoursAction extends Action
+{
+    use TraitIdMultiple;
+    use TraitCache;
+    use TraitCache;
+
+    public ?string $from = null;
+    public ?string $to = null;
+
+    /**
+     * Set the date to retrieve hours from.
+     *
+     * @param string|\DateTimeInterface|null $from Value to set. Strings should
+     *                                             be in yyyy-mm-dd format
+     * @return self A reference to this object for method chaining.
+     * @throws ActionException If an invalid date is specified.
+     */
+    final public function setFrom($from): self
+    {
+        $this->from = self::buildDateString($from);
+
+        return $this;
+    }
+
+    /**
+     * Set the date to retrieve hours to.
+     *
+     * @param string|\DateTimeInterface|null $to Value to set. Strings should
+     *                                           be in yyyy-mm-dd format
+     * @return self A reference to this object for method chaining.
+     * @throws ActionException If an invalid date is specified.
+     */
+    final public function setTo($to): self
+    {
+        $this->to = self::buildDateString($to);
+
+        return $this;
+    }
+
+    /**
+     * @return HoursData[]
+     * @throws \Lits\LibCal\Exception\ClientException
+     */
+    final public function send(): array
+    {
+        $uri = '/' . Client::VERSION . '/hours';
+        $uri = $this->addId($uri);
+        $uri = self::addQuery($uri, 'from', $this->from);
+        $uri = self::addQuery($uri, 'to', $this->to);
+
+        /** @var HoursData[] $result */
+        $result = $this->memoize(
+            $uri,
+            fn (string $uri) => HoursData::fromJsonAsArray(
+                $this->client->get($uri)
+            )
+        );
+
+        return $result;
+    }
+
+    /**
+     * Return a date string in 'yyyy-mm-dd' format.
+     *
+     * @param string|\DateTimeInterface|null $date The date.
+     * @return string|null The date in 'yyyy-mm-dd' format. Null if null input.
+     * @throws ActionException If an invalid date is specified.
+     */
+    private static function buildDateString($date): ?string
+    {
+        if (\is_null($date)) {
+            return null;
+        }
+
+        if ($date instanceof \DateTimeInterface) {
+            return $date->format('Y-m-d');
+        }
+
+        if (!self::dateStringIsValid($date)) {
+            throw new ActionException('Invalid date specified');
+        }
+
+        return $date;
+    }
+
+    /**
+     * Is string date in 'yyyy-mm-dd' format?
+     *
+     * @param string $date Value to set.
+     * @return bool true if the string is in 'yyyy-mm-dd' format,
+     *              false if not
+     */
+    private static function dateStringIsValid(string $date): bool
+    {
+        $date = \filter_var(
+            $date,
+            \FILTER_VALIDATE_REGEXP,
+            ['options' => ['regexp' => '/^\d{4}-\d{2}-\d{2}$/']]
+        );
+
+        return $date !== false;
+    }
+}

--- a/src/Client.php
+++ b/src/Client.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Lits\LibCal;
 
+use Lits\LibCal\Action\HoursAction;
 use Lits\LibCal\Action\SpaceAction;
 use Lits\LibCal\Data\TokenData;
 use Lits\LibCal\Exception\ClientException;
@@ -180,6 +181,17 @@ final class Client
     public function space(): SpaceAction
     {
         return new SpaceAction($this);
+    }
+
+    /**
+     * Retrieve action for LibCal Hours API.
+     *
+     * @param int|int[] $id The id of the location to retrieve.
+     * @return HoursAction Hours lookup action.
+     */
+    public function hours($id): HoursAction
+    {
+        return new HoursAction($this, $id);
     }
 
     /**

--- a/src/Data/Hours/DateData.php
+++ b/src/Data/Hours/DateData.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lits\LibCal\Data\Hours;
+
+use Lits\LibCal\Data;
+
+class DateData extends Data
+{
+    public ?string $status = null;
+
+    public ?string $note = null;
+
+    /** @var OpeningHoursData[] */
+    public array $hours = [];
+}

--- a/src/Data/Hours/HoursData.php
+++ b/src/Data/Hours/HoursData.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lits\LibCal\Data\Hours;
+
+use Lits\LibCal\Data;
+
+class HoursData extends Data
+{
+    public ?int $lid = null;
+    public ?string $name = null;
+    public ?string $category = null;
+    public ?string $desc = null;
+
+    public ?string $url = null;
+    public ?string $contact = null;
+    public ?string $lat = null;
+    public ?string $lon = null;
+    public ?string $color = null;
+    public ?string $fn = null;
+
+    public string $parent_lid;
+
+    /** @var DateData[] $dates */
+    public array $dates = [];
+}

--- a/src/Data/Hours/OpeningHoursData.php
+++ b/src/Data/Hours/OpeningHoursData.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lits\LibCal\Data\Hours;
+
+use Lits\LibCal\Data;
+
+class OpeningHoursData extends Data
+{
+    public ?string $from = null;
+    public ?string $to = null;
+}


### PR DESCRIPTION
We use both the Spaces and Hours endpoints, so I added access to `/hours`.

```PHP
$response = $client->hours([501, 23312])
                   ->setFrom('2024-06-01')
                   ->setTo('2024-06-02')
                   ->send();
```

Output looks like:

```
array(1) {
  [0]=>
  object(Lits\LibCal\Data\Hours\HoursData)#36 (11) {
    ["lid"]=>
    int(501)
    ["name"]=>
    string(15) "O'Neill Library"
    ["category"]=>
    string(7) "library"
    ["desc"]=>
    string(0) ""
    ["url"]=>
    string(37) "https://libguides.bc.edu/oneill/hours"
    ["contact"]=>
    string(0) ""
    ["lat"]=>
    string(0) ""
    ["lon"]=>
    NULL
    ["color"]=>
    string(7) "#000000"
    ["fn"]=>
    string(0) ""
    ["parent_lid"]=>
    uninitialized(string)
    ["dates"]=>
    array(2) {
      ["2024-06-01"]=>
      object(Lits\LibCal\Data\Hours\DateData)#54 (3) {
        ["status"]=>
        string(4) "open"
        ["note"]=>
        NULL
        ["hours"]=>
        array(1) {
          [0]=>
          object(Lits\LibCal\Data\Hours\OpeningHoursData)#50 (2) {
            ["from"]=>
            string(6) "9:00am"
            ["to"]=>
            string(6) "5:00pm"
          }
        }
      }
      ["2024-06-02"]=>
      object(Lits\LibCal\Data\Hours\DateData)#48 (3) {
        ["status"]=>
        string(4) "open"
        ["note"]=>
        NULL
        ["hours"]=>
        array(1) {
          [0]=>
          object(Lits\LibCal\Data\Hours\OpeningHoursData)#60 (2) {
            ["from"]=>
            string(7) "11:00am"
            ["to"]=>
            string(6) "7:00pm"
          }
        }
      }
    }
  }
}
```

It passes all tests under PHP7.4.

A couple of points to notice:

- The Hours API only has a single endpoint, which makes `Client::hours($id)` a little different from `Client::space()`. I tried to make it fit in spirit.
- The response format for the `/hours` endpoint is a bit wonky and isn't documented correctly in LibCal. Specifically, the `dates` value is not an array, it's an object with date strings as names and date objects as values. This makes it kind of hard to extract DateTime objects for hours without resorting to a `HoursData::setDate()` function.

    I decided to stick with the out-of-the-box functionality JsonMapper provides and just represent `dates` as an associative array keyed by the string value of the date ('2024-06-02') pointing to an object that contains hours as strings ('11:00am'). Our use case is display and not manipulation, so this was sufficient.

And thanks for the library, btw!

Cheers,
Ben